### PR TITLE
removed 'scheme' in doc when calling problem creator in 1d_diff_reac

### DIFF
--- a/docs/src/diffusion_reaction_1d.rst
+++ b/docs/src/diffusion_reaction_1d.rst
@@ -108,7 +108,7 @@ Python synopsis
 
    # A. constructor for problem using default values
    probId  = pda.DiffusionReaction1d.ProblemA
-   problem = pda.create_problem(meshObj, probId, scheme)
+   problem = pda.create_problem(meshObj, probId)
 
    # B. setting custom coefficients
    myD, myK = 0.2, 0.001
@@ -117,5 +117,5 @@ Python synopsis
    # C. setting custom coefficients and custom source function
    myD, myK = 0.55, 0.002
    mysource = lambda x, time : np.sin(math.pi*x) *x*x * 4.*np.cos(4.*math.pi*x)
-   problem = pda.create_diffusion_reaction_1d_problem_A(meshObj, probId, scheme, \
+   problem = pda.create_diffusion_reaction_1d_problem_A(meshObj, probId, \
 							mysource, myD, myK)


### PR DESCRIPTION
'scheme' is not needed when creating a `diffusion_reaction_1d_problem`.  See for example `test_1d_diffusion_reaction.py` in tests_py